### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash.uniq": "^4.5.0",
     "lodash.zipobject": "^4.1.3",
     "media-typer": "^1.1.0",
-    "multer": "^1.4.2",
+    "multer": "^2.0.0-beta.1",
     "ono": "^7.0.0",
     "path-to-regexp": "^6.0.0"
   },


### PR DESCRIPTION
Revert to a secure version of multer (2.0.0-beta.1). Multer 1.4.2 has a security issue per the Sonatype Nexus IQ and I am proposing this change.